### PR TITLE
onlymobile magic tag allows for html block elements

### DIFF
--- a/MobileDetect.i18n.magic.php
+++ b/MobileDetect.i18n.magic.php
@@ -16,5 +16,6 @@ $magicWords = [];
  */
 $magicWords['en'] = [
 	'nomobile' => [ 0, 'nomobile' ],
-	'mobileonly' => [ 0, 'mobileonly' ]
+	'mobileonly' => [ 0, 'mobileonly' ],
+	'onlymobile' => [ 0, 'onlymobile' ]
 ];

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -46,6 +46,20 @@ class Hooks implements
 		$parser->setFunctionHook( 'nomobile', static function ( Parser $parser, $input = '' ) {
 			return '<span class="nomobile">' . $parser->recursiveTagParse( $input ) . '</span>';
 		} );
+
+		$parser->setHook( 'onlymobile', static function ( $input, array $args, Parser $parser, PPFrame $frame ) {
+			if ( self::isMobile() ) {
+				return $parser->recursiveTagParse( $input );
+			}
+			return '';
+		} );
+
+		$parser->setFunctionHook( 'onlymobile', static function ( Parser $parser, $input = '' ) {
+			if ( self::isMobile() ) {
+				return $parser->recursiveTagParse( $input );
+			}
+			return '';
+		} );
 	}
 
 	/**


### PR DESCRIPTION
I have been having trouble using the `<mobileonly>` tag for block elements such as `<div>`s, because the `<mobileonly>` tag will ouput a `<span>`, but `<span>`s are inline elements and cannot be wrappers for block elements. Which means that the `<mobileonly>` functionality breaks and the block elements show when they're not supposed to.

You can see an example here: https://en.seminaverbi.bibleget.io/wiki/User:Johnrdorazio#Testing_MobileDetect_tags

Basically the way MobileDetect currently works, it's only possible to use the `<mobileonly>` tag for inline elements (single words, phrases) but not for controlling the output of block level elements. Perhaps `<mobileonly>` could be called something like `<mobileonlyinline>`. But rather than change the name of the `<mobileonly>` tag with the risk of messing up functionality for sites that are using it, I figured I would just introduce a new tag with a similar name `<onlymobile>`, which will correctly handle block level elements.
